### PR TITLE
feat(slo): MCP SLO Observability v2.3.4

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.SynapseLayer/synapse-layer",
   "title": "Synapse Layer",
   "description": "Persistent memory infrastructure for AI agents — encrypted, governed, and cross-agent. State Continuity Layer.",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "websiteUrl": "https://synapselayer.org",
   "repository": {
     "url": "https://github.com/SynapseLayer/synapse-layer",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "synapse-layer",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -3,7 +3,7 @@ displayName: "Synapse Layer"
 description: >
   Persistent memory infrastructure for AI agents — encrypted,
   governed, and cross-agent. State Continuity Layer.
-version: "2.3.3"
+version: "2.3.4"
 icon: "🧠"
 sourceUrl: "https://github.com/SynapseLayer/synapse-layer"
 homepage: "https://synapselayer.org"


### PR DESCRIPTION
## MCP SLO Observability & Uptime Proof Loop — v2.3.4

### Changes
- **McpRequestLog** Prisma model (append-only, zero PII)
- **lib/telemetry.ts** — fire-and-forget request logging
- **lib/metrics.ts** — SLO report engine (p50/p95/p99, 24h/7d)
- **slo_report** MCP tool (admin-only, `timingSafeEqual`)
- **health_check** upgraded to 3-tier (healthy/degraded/unhealthy)
- All 18 POST exit paths instrumented
- Version bumped to 2.3.4
- Supabase comment removed (claims governance)

### Security Gate: 8/8 PASS ✅
1. McpRequestLog zero PII fields
2. slo_report uses timingSafeEqual
3. health_check always HTTP 200
4. No prohibited claims
5. ADMIN_TOKEN configured
6. Version consistency (route.ts/smithery.yaml/server.json)
7. ≥15 logMcpRequest calls covering all exits
8. slo_report in AUTH_EXEMPT + TOOLS

### ⚠️ DO NOT MERGE — Human review required per Synapse Protocol