### PR TITLE
fix(smithery): P0.A — Add x-from/x-to header extensions for token forwarding

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -28,6 +28,10 @@ configSchema:
       type: "string"
       title: "Synapse Connect Token"
       description: "Your Synapse Connect Token. Get it at synapselayer.org → Dashboard → Connect."
+      x-from:
+        header: "x-connect-token"
+      x-to:
+        header: "x-connect-token"
     agent_id:
       type: "string"
       title: "Agent ID"


### PR DESCRIPTION
## P0.A — Smithery Recall Hotfix

Adds x-from/x-to extensions to connect_token in configSchema for proper Smithery Gateway token forwarding.