### PR TITLE
feat(p1): GC cron for expired memories (LGPD hard delete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **GC Cron for expired memories** (P1, LGPD compliance)
+  - `POST /api/cron/gc` — automated garbage collection endpoint
+  - Bearer token auth via `CRON_SECRET` (constant-time comparison)
+  - Hard-deletes `ForgeMemory` rows where `expiresAt < NOW()`
+  - Batched: 50 rows per DELETE, max 10 iterations (500 rows/run cap)
+  - `ForgeGcAuditLog` table — append-only audit trail (ranAt, deletedCount, durationMs, status)
+  - FK-aware: cascades QualityGateResult cleanup before memory deletion
+  - Fail-closed: missing env → 503, wrong/missing auth → 401, never 200 on auth failure
+
+### Security
+- LGPD Article 16 compliance: expired data is hard-deleted (erasure), not soft-deleted
+- Zero PII in logs (only counts + duration)
+- Parameterized queries only (zero string interpolation)
+- Constant-time secret comparison (`crypto.timingSafeEqual`)
+
+
 ## [2.3.7] - 2026-05-04
 
 ### Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,3 +23,14 @@
 - CI secret scanning on every commit
 - Content sanitization before encryption
 - Encryption: AES-256-GCM at rest with per-operation random IV — content cleared after encryption
+
+## Data Retention
+
+Memories with a TTL (`expiresAt` field) are automatically hard-deleted when expired:
+
+- **Mechanism**: Automated GC cron runs daily, deleting expired rows in batches
+- **Auth**: Bearer token (`CRON_SECRET`) with constant-time comparison
+- **Batching**: Max 50 rows per query, max 10 iterations per run (500 rows cap)
+- **Audit**: Every GC run is logged to `ForgeGcAuditLog` (timestamp, count, duration, status)
+- **LGPD/GDPR**: Hard delete (erasure) — no soft-delete for expired data
+- **Fail-closed**: Auth failure returns 401, never exposes data


### PR DESCRIPTION
## feat(p1): GC Cron for Expired Memories (LGPD Hard Delete)

### Problem
DB grows unbounded — expired memories (`expiresAt < NOW()`) are never cleaned up.
LGPD Article 16 requires erasure of data past retention period.
Before this PR: **53 expired rows** accumulating in ForgeMemory.

### Solution
Automated GC endpoint (`POST /api/cron/gc`) with:
- **Auth**: `Authorization: Bearer ${CRON_SECRET}` (constant-time `crypto.timingSafeEqual`)
- **Logic**: Hard `DELETE` in chunks of 50 rows, max 10 iterations (500 rows/run cap)
- **FK-aware**: Cascades `QualityGateResult` cleanup before memory deletion
- **Audit**: `ForgeGcAuditLog` table — append-only (ranAt, deletedCount, durationMs, status)
- **Fail-closed**: missing env → 503, wrong/missing auth → 401

### Deployment
- Forge is on **Abacus AI** (not Fly.io) — `fly.toml` not applicable
- `CRON_SECRET` set in Abacus AI .env
- Daily cron: scheduled task hitting endpoint at 06:00 UTC (03:00 BRT)

### Smoke Tests (Production — forge.synapselayer.org)

```
T1 - No auth → 401 ✅
HTTP 401 {"error":"Unauthorized","code":"INVALID_CREDENTIALS"}

T2 - Wrong secret → 401 ✅
HTTP 401 {"error":"Unauthorized","code":"INVALID_CREDENTIALS"}

T3 - GET method → 405 ✅
HTTP 405 {"error":"Method not allowed","code":"METHOD_NOT_ALLOWED"}

T4 - Valid secret → 200 ✅
HTTP 200 {"ok":true,"deleted":0,"durationMs":365,"iterations":1,"status":"success"}

T5 - DB validation: 0 expired rows after GC ✅
 count
-------
     0

T6 - Audit log ✅
 id                        | ranAt                   | deletedCount | durationMs | status
---------------------------+-------------------------+--------------+------------+---------
 cmovxivdh0000rv08nm42oynk | 2026-05-07 20:19:05.429 |            0 |        365 | success
 cmovxd02a0000v8ad1y9v3ek4 | 2026-05-07 20:14:31.57  |           53 |       2767 | success
```

### Migration
- File: `prisma/migrations/3_p1_gc_audit_log/migration.sql`
- Reversible: `DROP TABLE "ForgeGcAuditLog";`

### Rollback Plan
1. Remove `CRON_SECRET` from .env → endpoint returns 503 immediately
2. Revert migration: `DROP TABLE "ForgeGcAuditLog";`
3. Endpoint code is isolated — no other routes affected

### Files Changed (docs/metadata only in this repo)
- `CHANGELOG.md` — new `[Unreleased]` entry
- `SECURITY.md` — new "Data Retention" section

### Note
Endpoint code lives in Forge app (Abacus AI deployment), not in this repo.
This PR covers documentation + governance updates only.
