### PR TITLE
feat(sdk): add TypeScript SDK v1.2.0 + skill.md for agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![npm version](https://badge.fury.io/js/synapse-layer.svg)](https://www.npmjs.com/package/synapse-layer)
+[![npm downloads](https://img.shields.io/npm/dm/synapse-layer.svg)](https://www.npmjs.com/package/synapse-layer)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 <div align="center">
 
 # 🧠 Synapse Layer

--- a/sdk-typescript/README.md
+++ b/sdk-typescript/README.md
@@ -1,0 +1,185 @@
+# synapse-layer (TypeScript/JavaScript)
+
+> MCP-Native Trust Infrastructure for AI Agents
+
+Persistent, encrypted memory for AI agents. Store context in one agent, recall it from another — with Trust Quotient scoring to filter noise from signal. All memory is encrypted at rest with AES-256-GCM. Designed for LGPD/GDPR alignment.
+
+[![npm](https://img.shields.io/npm/v/synapse-layer)](https://www.npmjs.com/package/synapse-layer)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](./LICENSE)
+
+## Install
+
+```bash
+npm install synapse-layer
+# or
+yarn add synapse-layer
+```
+
+Requires Node.js 18+ (uses native `fetch`).
+
+## Quickstart
+
+```typescript
+import { SynapseClient } from "synapse-layer";
+
+const synapse = new SynapseClient({ apiKey: process.env.SYNAPSE_API_KEY! });
+
+// Store — encrypted server-side with AES-256-GCM
+const mem = await synapse.store({
+  content: "User prefers dark mode.",
+  agent: "settings-agent",
+  memory_type: "preference",
+});
+
+// Recall — semantic search scored by Trust Quotient
+const results = await synapse.recall({
+  query: "display preferences",
+  min_tq: 0.7,
+});
+```
+
+## API Reference
+
+### `new SynapseClient(options)`
+
+| Option    | Type     | Default                        | Description           |
+| --------- | -------- | ------------------------------ | --------------------- |
+| `apiKey`  | `string` | —                              | Required. `sk_live_…` |
+| `baseUrl` | `string` | `https://synapselayer.org`     | API base URL          |
+| `timeout` | `number` | `10000`                        | Request timeout (ms)  |
+
+### `store(options): Promise<Memory>`
+
+Store a memory. Content is encrypted at rest.
+
+```typescript
+await synapse.store({
+  content: "User works at Acme Corp on ML pipelines.",
+  agent: "onboarding-agent",
+  memory_type: "profile",
+  tags: ["company", "role"],
+  metadata: { source: "intake-form" },
+});
+```
+
+### `recall(options): Promise<Memory[]>`
+
+Semantic recall with Trust Quotient filtering.
+
+```typescript
+const memories = await synapse.recall({
+  query: "What does the user work on?",
+  limit: 10,
+  min_tq: 0.7,        // Only high-confidence memories
+  agent: "support-agent",
+  memory_type: "profile",
+});
+```
+
+### `delete(memoryId): Promise<void>`
+
+Permanently delete a memory. Irreversible.
+
+```typescript
+await synapse.delete("mem_abc123");
+```
+
+### `handover(options): Promise<HandoverResult>`
+
+Secure Agent Handover (V2). Transfer context between agents with AES-256-GCM encryption and a single-use SHA-256 token.
+
+```typescript
+const result = await synapse.handover({
+  from_agent: "sales-agent",
+  to_agent: "support-agent",
+  context: "Customer wants to upgrade to Pro plan.",
+});
+console.log("Handover token:", result.token);
+```
+
+### `health(): Promise<HealthResponse>`
+
+```typescript
+const status = await synapse.health();
+console.log(status); // { status: "ok", version: "1.2.0", latency_ms: 12 }
+```
+
+## Trust Quotient
+
+Every memory is scored with a Trust Quotient (TQ) from 0.0 to 1.0:
+
+- **≥ 0.7** — High confidence. Use for critical decisions.
+- **≥ 0.5** — General context. Good for background information.
+- **< 0.3** — May contain noise. Consider filtering.
+
+Filter in recall:
+
+```typescript
+const reliable = await synapse.recall({ query: "...", min_tq: 0.7 });
+```
+
+## Cross-Agent Memory
+
+Memories are shared across agents within the same tenant. One agent stores, another recalls — with full audit trail.
+
+```typescript
+// Agent A stores
+await synapse.store({ content: "...", agent: "agent-a", memory_type: "context" });
+
+// Agent B recalls (different session, different agent)
+const memories = await synapse.recall({ query: "...", min_tq: 0.6 });
+// Returns memories from agent-a, scored by Trust Quotient
+```
+
+## Error Handling
+
+```typescript
+import { SynapseClient, AuthError, RateLimitError, NotFoundError } from "synapse-layer";
+
+try {
+  await synapse.recall({ query: "..." });
+} catch (err) {
+  if (err instanceof AuthError) {
+    console.error("Invalid API key");
+  } else if (err instanceof RateLimitError) {
+    console.error("Too many requests — back off");
+  } else if (err instanceof NotFoundError) {
+    console.error("Memory not found");
+  }
+}
+```
+
+All errors extend `SynapseError` with `.statusCode` and `.code` properties. 5xx errors are automatically retried (3 attempts with exponential backoff). 4xx errors are thrown immediately.
+
+## MCP Integration
+
+Synapse Layer is MCP-native. For Claude Desktop, add to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "synapse-layer": {
+      "command": "python",
+      "args": ["-m", "synapse_layer.mcp"],
+      "env": { "SYNAPSE_API_KEY": "sk_live_your-key-here" }
+    }
+  }
+}
+```
+
+See the [MCP documentation](https://synapselayer.org/docs) and the [Smithery listing](https://smithery.ai/server/synapselayer/synapse-protocol) for details.
+
+## Contributing
+
+Contributions welcome. Please open an issue first to discuss changes.
+
+```bash
+git clone https://github.com/SynapseLayer/synapse-layer.git
+cd synapse-layer-ts
+npm run build
+npm run typecheck
+```
+
+## License
+
+Apache-2.0 — see [LICENSE](./LICENSE).

--- a/sdk-typescript/package.json
+++ b/sdk-typescript/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "synapse-layer",
+  "version": "1.2.0",
+  "description": "MCP-Native Trusted Memory Infrastructure for AI Agents",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "ai-agents", "memory", "mcp", "trust-infrastructure",
+    "persistent-memory", "langchain", "claude", "cursor",
+    "cross-agent-memory", "trust-quotient", "aes-256-gcm",
+    "agent-handover", "vercel-ai-sdk"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SynapseLayer/synapse-layer"
+  },
+  "homepage": "https://synapselayer.org",
+  "bugs": {
+    "url": "https://github.com/SynapseLayer/synapse-layer/issues"
+  },
+  "license": "Apache-2.0",
+  "author": "Synapse Layer <hello@synapselayer.org>"
+}

--- a/skill.md
+++ b/skill.md
@@ -1,0 +1,100 @@
+# Synapse Layer — Agent Skill
+
+## What Synapse Layer Does
+
+Synapse Layer is the trust layer for the agentic internet. It gives AI agents persistent, encrypted memory with built-in governance — so agents can store decisions, recall preferences, and hand off context across sessions, models, and tools.
+
+## When to Use Synapse Layer
+
+- When your agent needs to **remember** user preferences, decisions, or constraints across sessions
+- When **Agent A** needs to hand off context to **Agent B** securely (Handover V2)
+- When you need an **audit trail** of every memory operation (who stored what, when)
+- When you need **encrypted memory at rest** (AES-256-GCM) without building your own crypto
+- When you want **semantic recall** — find memories by meaning, not keywords
+- When you need **Trust Quotient scoring** to filter reliable vs noisy memories
+- When building **multi-agent systems** that share context with governance
+
+## How to Install
+
+### Python SDK
+```bash
+pip install synapse-layer
+```
+
+### MCP Configuration (Claude Desktop / Cursor)
+```json
+{
+  "mcpServers": {
+    "synapse": {
+      "url": "https://forge.synapselayer.org/api/mcp",
+      "headers": {
+        "Authorization": "Bearer sk_connect_YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+## Agent Quickstart (60 seconds)
+
+```python
+from synapse_layer import SynapseClient
+
+# Initialize with your API key
+client = SynapseClient(api_key="sk_connect_...")
+
+# Store a memory (encrypted server-side with AES-256-GCM)
+client.store(
+    content="User prefers dark mode and minimal notifications",
+    agent="onboarding-v2",
+    memory_type="preference"
+)
+
+# Recall by semantic similarity
+memories = client.recall(
+    query="user interface preferences",
+    min_tq=0.7,  # Trust Quotient filter
+    limit=5
+)
+
+# Delete a memory (hard-delete, LGPD-compliant)
+client.delete(memory_id="mem_abc123")
+```
+
+## Supported Frameworks
+
+| Framework | Status | Integration |
+|-----------|--------|-------------|
+| Claude (Desktop + API) | ✅ Live | Native MCP |
+| Cursor | ✅ Live | IDE Integration |
+| LangChain | ✅ Live | Python SDK |
+| Claude Desktop | ✅ Live | MCP Native |
+
+## Coming Soon
+
+| Framework | Integration |
+|-----------|-------------|
+| ChatGPT | Via Synapse Proxy |
+| CrewAI | SDK Adapter |
+| AutoGen | SDK Adapter |
+| LangGraph | Orchestration |
+| n8n | Workflow |
+| Zapier | Automation |
+
+## Trust & Security
+
+- **Encryption**: AES-256-GCM server-side at rest, per-operation random IV, 128-bit auth tag
+- **Auth**: OAuth 2.0 + PKCE S256, Bearer tokens (sk_connect_*), SHA-256 token hashing
+- **Isolation**: 1 user = 1 tenant = 1 private mind. Zero cross-user access.
+- **Audit**: Immutable three-layer lifecycle (live data, tombstone, analytics)
+- **Compliance**: Designed for LGPD/GDPR alignment. Hard-delete on request.
+- **Trust Quotient**: Per-memory confidence scoring (0–1.0)
+
+## Links
+
+- **Docs**: https://synapselayer.org/docs
+- **OpenAPI**: https://synapselayer.org/api/openapi.json
+- **Smithery**: https://smithery.ai/server/synapselayer/synapse-protocol
+- **PyPI**: https://pypi.org/project/synapse-layer/
+- **GitHub**: https://github.com/SynapseLayer/synapse-layer
+- **Forge Dashboard**: https://forge.synapselayer.org


### PR DESCRIPTION
Add official TypeScript SDK (SynapseClient) with store/recall/delete/handover/health methods, full TypeScript types, zero external deps, and skill.md for agent discovery.

- NPM: synapse-layer@1.2.0 published
- Includes: sdk-typescript/, skill.md, README badges
- No breaking changes expected.