### PR TITLE
docs(governance): sanitize compliance wording and remove sensitive terminology

### DIFF
--- a/docs/distribution/SMITHERY_SUBMISSION.md
+++ b/docs/distribution/SMITHERY_SUBMISSION.md
@@ -82,7 +82,7 @@ Apache-2.0
 Ismael Marchi — [@synapselayer](https://x.com/synapselayer)
 
 ### Tags
-`agent-memory` `persistent-context` `long-term-memory` `mcp-memory` `deterministic-recall` `encrypted-at-rest` `trust-quotient` `aes-256-gcm` `encrypted-at-rest` `continuous-consciousness` `sqlite-backend` `langchain` `crewai` `autogen` `llamaindex` `semantic-kernel`
+`agent-memory` `persistent-context` `long-term-memory` `mcp-memory` `deterministic-recall` `encrypted-at-rest` `trust-quotient` `aes-256-gcm` `encrypted-at-rest` `sqlite-backend` `langchain` `crewai` `autogen` `llamaindex` `semantic-kernel`
 
 ### Numbers
 - 481 tests | 90% coverage

--- a/glama.json
+++ b/glama.json
@@ -123,7 +123,7 @@
     },
     {
       "name": "delete_memory",
-      "description": "Hard-delete a specific memory by ID. LGPD/GDPR compliant — removes all PII. Irreversible. A tombstone record without PII is preserved for audit trail integrity. Use this when a user requests data deletion or when removing outdated/incorrect memories. Destructive — cannot be undone.",
+      "description": "Hard-delete a specific memory by ID. Designed for LGPD/GDPR alignment — removes all PII. Irreversible. A tombstone record without PII is preserved for audit trail integrity. Use this when a user requests data deletion or when removing outdated/incorrect memories. Destructive — cannot be undone.",
       "annotations": {
         "readOnlyHint": false,
         "destructiveHint": true,


### PR DESCRIPTION
Scope:
- Sanitize compliance wording in glama.json
- Remove sensitive terminology from Smithery submission

No functional changes.
No version bump.
No release.
No tag.