### PR TITLE
fix(mcp): dedup marketplace manifests and align to v2.4.4

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -34,7 +34,7 @@
   ],
   "auth": {
     "type": "bearer",
-    "token_prefix": "sk_live_",
+    "token_prefix": "sk_connect_",
     "signup_url": "https://forge.synapselayer.org/signup"
   },
   "tools": [
@@ -145,7 +145,7 @@
         "synapse-layer"
       ],
       "env": {
-        "SYNAPSE_API_KEY": "sk_live_your_key_here",
+        "SYNAPSE_API_KEY": "sk_connect_your_key_here",
         "SYNAPSE_AGENT_ID": "my-agent"
       }
     },
@@ -153,7 +153,7 @@
       "url": "https://forge.synapselayer.org/api/mcp",
       "transport": "streamable-http",
       "headers": {
-        "Authorization": "Bearer sk_live_your_key_here"
+        "x-connect-token": "sk_connect_your_key_here"
       }
     }
   },

--- a/server.json
+++ b/server.json
@@ -26,7 +26,7 @@
         },
         {
           "name": "SYNAPSE_API_KEY",
-          "description": "Bearer token for API authentication (sk_live_*).",
+          "description": "Connect token for API authentication (sk_connect_*).",
           "isSecret": true
         },
         {


### PR DESCRIPTION
- Replace sk_live_ with sk_connect_ in server.json env description and glama.json auth/install/remote sections (forensic audit C1)
- Replace Authorization: Bearer with x-connect-token in glama.json remote headers (align with Forge header-first auth contract)
- smithery.yaml already correct — no changes needed
- Verified: zero prohibited claims, all endpoints /api/mcp, all versions 2.4.4, pyproject.toml untouched

## Description

Brief description of the changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/CD improvement

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally with `pytest`
- [ ] I have updated documentation if needed
- [ ] No secrets, tokens, or PII in the diff
