### PR TITLE
docs(sdk): add source gap notice for sdk-typescript v1.2.0

### DIFF
--- a/sdk-typescript/src/README-SOURCE-GAP.md
+++ b/sdk-typescript/src/README-SOURCE-GAP.md
@@ -1,0 +1,18 @@
+# SDK TypeScript — Source Gap Notice
+
+**Status:** dist/ recuperado do npm@1.2.0 (2026-07-28).
+**Gap:** O código-fonte `.ts` que gerou este dist/ não foi commitado no working tree local.
+
+## Evidência
+- npm `synapse-layer@1.2.0`: dist/ com 8 arquivos compilados (26168 bytes, 18 files).
+- Commit local: `e75925e feat(sdk): add TypeScript SDK v1.2.0` — apenas README+package.json.
+- Hipótese: build foi feito em outra máquina/estado e publicado sem commit do src/.
+
+## Próximos Passos (Roadmap)
+1. Reconstruir `src/` a partir do `dist/` (decompilação assistida por IA).
+2. Ou reescrever `src/` do zero alinhado ao `dist/` existente como contrato de API.
+3. Publicar `synapse-layer@2.4.6` após reconstrução e testes.
+
+## Versão Canônica
+- Local `package.json`: version `2.4.6` (alinhamento canônico Forge).
+- npm latest: `1.2.0` (bump canônico pendente de publicação).


### PR DESCRIPTION
## Contexto

Recupera e publica o commit de documentação originalmente criado no ambiente isolado:

- Commit de origem: `6a08884`
- Transferência: patch Git exportado, codificado em Base64, validado localmente e aplicado via `git am`
- Integridade do patch: `1894 bytes`

## Alteração

Adiciona:

- `sdk-typescript/src/README-SOURCE-GAP.md`

O documento registra de forma transparente que a distribuição compilada `dist/` do pacote npm foi recuperada, enquanto o código-fonte TypeScript original em `src/` não estava disponível no working tree auditado.

## Segurança e governança

- Sem alteração de runtime
- Sem alteração de API
- Sem segredos, tokens ou PII
- Sem mudança em Forge
- Sem claims proibidos de branding
- Escopo: documentação de auditoria e reconciliação do SDK