### PR TITLE
docs: canonicalize auth to x-connect-token (llms-full.txt)

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -115,7 +115,7 @@ Pipeline stages:
 
 - **Agent tokens**: `sk_connect_...` (current), legacy `sk_live_...` (deprecated).
 - **Human flows**: Magic Link (`ml_...`) and OAuth 2.0 + PKCE (S256).
-- Send as `Authorization: Bearer <token>`.
+- Send as `x-connect-token: <token>`.
 - Verify before heavy work: `GET /api/connect/health` returns identity, plan,
   and memory count.
 - Get your key at https://forge.synapselayer.org/dashboard/connect

--- a/skill.md
+++ b/skill.md
@@ -28,7 +28,7 @@ pip install synapse-layer
     "synapse": {
       "url": "https://forge.synapselayer.org/api/mcp",
       "headers": {
-        "Authorization": "Bearer sk_connect_YOUR_TOKEN"
+        "x-connect-token": "sk_connect_YOUR_TOKEN"
       }
     }
   }
@@ -41,7 +41,7 @@ pip install synapse-layer
 from synapse_layer import SynapseClient
 
 # Initialize with your API key
-client = SynapseClient(api_key="sk_connect_...")
+client = SynapseClient(token="sk_connect_...")
 
 # Store a memory (encrypted server-side with AES-256-GCM)
 client.store(


### PR DESCRIPTION
Canonicalize public auth surface to header-first `x-connect-token` (never `Authorization: Bearer`, never token in URL).

**Changes (2 files):**
- `llms-full.txt` §6 (line 118): `- Send as \`Authorization: Bearer <token>\`.` → `- Send as \`x-connect-token: <token>\`.` New sha256 `b2567aff9b2ba85266b1f514ebf47604506ba54d14c0aa1a2ce19bf75efb0cf5` (1 line changed vs 733e0e8).
- `skill.md`: MCP config header `Authorization: Bearer` → `x-connect-token`; `SynapseClient(api_key=…)` → `SynapseClient(token=…)` (canonical per SDK docstring + README).

`llms.txt` unchanged (sha256 `5be042439dc1b8253df41097a505a58b747707fc8316e426f08ea20cbb60f7f0`). `docs/cookbooks.md` had no matching occurrences. SDK code, tests, releases, YAML/JSON left untouched.

No force push, no merge — for review.